### PR TITLE
AD-577 - E2E - token handling bug

### DIFF
--- a/e2e-polybft/cardanofw/test-cardano-token-tx.go
+++ b/e2e-polybft/cardanofw/test-cardano-token-tx.go
@@ -179,8 +179,10 @@ func createNativeTokenTx(
 	}
 	desiredLovelaceAmount := PotentialFee + lovelaceAmount + max(minUtxoLovelace, MinUTxODefaultValue)
 
-	inputs, err := cardanowallet.GetUTXOsForAmount(
-		allUtxos, cardanowallet.AdaTokenName, desiredLovelaceAmount, maxInputs)
+	// This is a hacky way to get inputs for both lovelace and tokens
+	// will do it this way, until skyline is merged to main
+	// after that, this can be removed
+	inputs, err := getInputs(allUtxos, desiredLovelaceAmount, tokens)
 	if err != nil {
 		return nil, "", err
 	}
@@ -230,6 +232,61 @@ func createNativeTokenTx(
 	}
 
 	return txSigned, txHash, nil
+}
+
+func getInputs(
+	allUtxos []cardanowallet.Utxo,
+	desiredLovelaceAmount uint64,
+	tokens []cardanowallet.TokenAmount,
+) (*cardanowallet.TxInputs, error) {
+	inputsMap := make(map[string]cardanowallet.TxInput)
+
+	inputsLovelace, err := cardanowallet.GetUTXOsForAmount(
+		allUtxos, cardanowallet.AdaTokenName, desiredLovelaceAmount, maxInputs)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, input := range inputsLovelace.Inputs {
+		inputsMap[input.String()] = input
+	}
+
+	for _, token := range tokens {
+		inputsToken, err := cardanowallet.GetUTXOsForAmount(
+			allUtxos, token.TokenName(), token.Amount, maxInputs)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, input := range inputsToken.Inputs {
+			inputsMap[input.String()] = input
+		}
+	}
+
+	utxoMap := make(map[string]cardanowallet.Utxo, len(allUtxos))
+	for _, utxo := range allUtxos {
+		utxoMap[fmt.Sprintf("%s#%d", utxo.Hash, utxo.Index)] = utxo
+	}
+
+	inputs := cardanowallet.TxInputs{
+		Inputs: make([]cardanowallet.TxInput, 0, len(inputsMap)),
+		Sum:    make(map[string]uint64),
+	}
+	for _, input := range inputsMap {
+		inputs.Inputs = append(inputs.Inputs, input)
+
+		utxo, exists := utxoMap[input.String()]
+		if !exists {
+			return nil, fmt.Errorf("can not find utxo for input %v", input.String())
+		}
+
+		inputs.Sum[cardanowallet.AdaTokenName] += utxo.Amount
+		for _, token := range utxo.Tokens {
+			inputs.Sum[token.TokenName()] += token.Amount
+		}
+	}
+
+	return &inputs, nil
 }
 
 func createMintTx(

--- a/e2e-polybft/e2e/apex_bridge_test.go
+++ b/e2e-polybft/e2e/apex_bridge_test.go
@@ -53,7 +53,7 @@ func Test_OnlyRunApexBridge_WithNexusAndVector(t *testing.T) {
 		cardanofw.WithUserCnt(1),
 	)
 
-	defer require.True(t, apex.ApexBridgeProcessesRunning())
+	// defer require.True(t, apex.ApexBridgeProcessesRunning())
 
 	oracleAPI, err := apex.GetBridgingAPI()
 	require.NoError(t, err)
@@ -118,6 +118,57 @@ func Test_OnlyRunApexBridge_WithNexusAndVector(t *testing.T) {
 		fmt.Printf("validator %d `--telemetry` flag telemetry url(s): %s\n",
 			i+1, apex.Config.GetTelemetryForValidatorIdx(i))
 	}
+
+	txProviderPrime, err := apex.PrimeInfo.GetTxProvider()
+	require.NoError(t, err)
+
+	minterUser := apex.Users[0]
+
+	brSubmitterUser, err := cardanofw.NewTestApexUser(
+		apex.Config.PrimeConfig.NetworkType, false, 0, false)
+	require.NoError(t, err)
+
+	brSubmitterWallet, _ := brSubmitterUser.GetCardanoWallet(cardanofw.ChainIDPrime)
+
+	const (
+		normalCnt        = 2
+		normalSendAmount = 1_000_000
+
+		withTokenCnt          = 2
+		withTokenSendLovelace = 2_000_000
+		withTokenSendToken    = 1_000_000
+	)
+
+	tokensFunded, err := cardanofw.FundUserWithToken(
+		ctx, cardanofw.ChainIDPrime, apex.Config.PrimeConfig.NetworkType, txProviderPrime,
+		minterUser, brSubmitterUser, uint64(100_000_000), uint64(withTokenSendToken*withTokenCnt*2))
+	require.NoError(t, err)
+
+	for range normalCnt {
+		_, err = apex.SubmitTx(ctx, cardanofw.ChainIDPrime, brSubmitterUser,
+			apex.PrimeInfo.MultisigAddr, new(big.Int).SetUint64(normalSendAmount), nil)
+		require.NoError(t, err)
+	}
+
+	for range withTokenCnt {
+		_, err = cardanofw.SendTxWithTokens(ctx, apex.Config.PrimeConfig.NetworkType, txProviderPrime,
+			brSubmitterWallet, apex.PrimeInfo.MultisigAddr,
+			withTokenSendLovelace, []infrawallet.TokenAmount{*tokensFunded}, nil,
+		)
+		require.NoError(t, err)
+	}
+
+	<-time.After(2 * time.Minute)
+
+	for idx := range apex.Config.BladeValidatorCount {
+		brValidator := apex.GetValidator(t, idx)
+		err = brValidator.Stop()
+		require.NoError(t, err)
+	}
+
+	fmt.Printf("setup complete. Prime real balance: %v lovelace, usable balance: %v lovelace\n",
+		withTokenCnt*withTokenSendLovelace+normalCnt*normalSendAmount+apex.Config.PrimeConfig.FundAmount,
+		normalCnt*normalSendAmount+apex.Config.PrimeConfig.FundAmount)
 
 	signalChannel := make(chan os.Signal, 1)
 	// Notify the signalChannel when the interrupt signal is received (Ctrl+C)

--- a/e2e-polybft/e2e/apex_bridge_test.go
+++ b/e2e-polybft/e2e/apex_bridge_test.go
@@ -53,7 +53,7 @@ func Test_OnlyRunApexBridge_WithNexusAndVector(t *testing.T) {
 		cardanofw.WithUserCnt(1),
 	)
 
-	// defer require.True(t, apex.ApexBridgeProcessesRunning())
+	defer require.True(t, apex.ApexBridgeProcessesRunning())
 
 	oracleAPI, err := apex.GetBridgingAPI()
 	require.NoError(t, err)
@@ -118,57 +118,6 @@ func Test_OnlyRunApexBridge_WithNexusAndVector(t *testing.T) {
 		fmt.Printf("validator %d `--telemetry` flag telemetry url(s): %s\n",
 			i+1, apex.Config.GetTelemetryForValidatorIdx(i))
 	}
-
-	txProviderPrime, err := apex.PrimeInfo.GetTxProvider()
-	require.NoError(t, err)
-
-	minterUser := apex.Users[0]
-
-	brSubmitterUser, err := cardanofw.NewTestApexUser(
-		apex.Config.PrimeConfig.NetworkType, false, 0, false)
-	require.NoError(t, err)
-
-	brSubmitterWallet, _ := brSubmitterUser.GetCardanoWallet(cardanofw.ChainIDPrime)
-
-	const (
-		normalCnt        = 2
-		normalSendAmount = 1_000_000
-
-		withTokenCnt          = 2
-		withTokenSendLovelace = 2_000_000
-		withTokenSendToken    = 1_000_000
-	)
-
-	tokensFunded, err := cardanofw.FundUserWithToken(
-		ctx, cardanofw.ChainIDPrime, apex.Config.PrimeConfig.NetworkType, txProviderPrime,
-		minterUser, brSubmitterUser, uint64(100_000_000), uint64(withTokenSendToken*withTokenCnt*2))
-	require.NoError(t, err)
-
-	for range normalCnt {
-		_, err = apex.SubmitTx(ctx, cardanofw.ChainIDPrime, brSubmitterUser,
-			apex.PrimeInfo.MultisigAddr, new(big.Int).SetUint64(normalSendAmount), nil)
-		require.NoError(t, err)
-	}
-
-	for range withTokenCnt {
-		_, err = cardanofw.SendTxWithTokens(ctx, apex.Config.PrimeConfig.NetworkType, txProviderPrime,
-			brSubmitterWallet, apex.PrimeInfo.MultisigAddr,
-			withTokenSendLovelace, []infrawallet.TokenAmount{*tokensFunded}, nil,
-		)
-		require.NoError(t, err)
-	}
-
-	<-time.After(2 * time.Minute)
-
-	for idx := range apex.Config.BladeValidatorCount {
-		brValidator := apex.GetValidator(t, idx)
-		err = brValidator.Stop()
-		require.NoError(t, err)
-	}
-
-	fmt.Printf("setup complete. Prime real balance: %v lovelace, usable balance: %v lovelace\n",
-		withTokenCnt*withTokenSendLovelace+normalCnt*normalSendAmount+apex.Config.PrimeConfig.FundAmount,
-		normalCnt*normalSendAmount+apex.Config.PrimeConfig.FundAmount)
 
 	signalChannel := make(chan os.Signal, 1)
 	// Notify the signalChannel when the interrupt signal is received (Ctrl+C)


### PR DESCRIPTION
# Description
When submitting multiple transactions that send native tokens, this error happens:

        	Error Trace:	/home/zoltan/apex/blade-apex-bridge/e2e-polybft/e2e/apex_bridge_test.go:158
        	Error:      	Received unexpected error:
        	            	status code 400: In and out value not conserved. The transaction must *exactly* balance: every input must be accounted for. There are various things counting as 'in balance': (a) the total value locked by inputs (or collateral inputs in case of a failing script), (b) rewards coming from withdrawals and (c) return deposits from stake credential or pool de-registration. In a similar fashion, various things count towards the 'out balance': (a) the total value assigned to each transaction output, (b) the fee and (c) any deposit for stake credential or pool registration. The field 'data.valueConsumed' contains the total 'in balance', and 'data.valueProduced' indicates the total amount counting as 'out balance'.
        	Test:       	Test_OnlyRunApexBridge_WithNexusAndVector

The solution gets utxos for lovelace, and then gets utxos for all the tokens, merges those inputs, and uses them in the transaction. Before this fix, only utxos for lovelace were fetched

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
