### PR TITLE
AD-644 E2E - Prepare testnet tests for Refund

### DIFF
--- a/e2e-polybft/e2e/testnet_bridge_test.go
+++ b/e2e-polybft/e2e/testnet_bridge_test.go
@@ -294,7 +294,7 @@ func TestE2E_ApexTestnetBridge_InvalidScenarios(t *testing.T) {
 	)
 
 	t.Run("Prime to Vector mismatch submitted and receiver amounts", func(t *testing.T) {
-		PrimeToVectorMismatchSubmittedAndReceiverAmounts(t, ctx, apex, apex.Users[0], requestStateTimeoutSec, false)
+		PrimeToVectorMismatchSubmittedAndReceiverAmounts(t, ctx, apex, apex.Users[0], requestStateTimeoutSec, true)
 	})
 
 	t.Run("Prime to Vector submitted invalid metadata - sliced off", func(t *testing.T) {
@@ -302,11 +302,11 @@ func TestE2E_ApexTestnetBridge_InvalidScenarios(t *testing.T) {
 	})
 
 	t.Run("Prime to Vector submitted invalid metadata - wrong type", func(t *testing.T) {
-		PrimeToVectorInvalidMetadataWrongType(t, ctx, apex, apex.Users[2], requestStateTimeoutSec, false)
+		PrimeToVectorInvalidMetadataWrongType(t, ctx, apex, apex.Users[2], requestStateTimeoutSec, true)
 	})
 
 	t.Run("Prime to Vector submitted invalid metadata - invalid destination", func(t *testing.T) {
-		PrimeToVectorInvalidMetadataInvalidDestination(t, ctx, apex, apex.Users[3], requestStateTimeoutSec, false)
+		PrimeToVectorInvalidMetadataInvalidDestination(t, ctx, apex, apex.Users[3], requestStateTimeoutSec, true)
 	})
 
 	t.Run("Prime to Vector submitted invalid metadata - invalid sender", func(t *testing.T) {
@@ -314,7 +314,7 @@ func TestE2E_ApexTestnetBridge_InvalidScenarios(t *testing.T) {
 	})
 
 	t.Run("Prime to Vector submitted invalid metadata - empty tx", func(t *testing.T) {
-		PrimeToVectorInvalidMetadataInvalidTransactions(t, ctx, apex, apex.Users[5], requestStateTimeoutSec, false)
+		PrimeToVectorInvalidMetadataInvalidTransactions(t, ctx, apex, apex.Users[5], requestStateTimeoutSec, true)
 	})
 
 	t.Run("Prime to Nexus submitter not enough funds", func(t *testing.T) {


### PR DESCRIPTION
Testnet tests on the refund branch are implemented as if refund is disabled. Once we deploy Reactor with refund enabled, we need the testnet tests to be ready for that