### PR TITLE
AD-666 - Increase confirmationBlocksNum for deployments

### DIFF
--- a/e2e-polybft/e2e/testnet_bridge_test.go
+++ b/e2e-polybft/e2e/testnet_bridge_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	defaultDstNumRetries = 100
+	defaultDstNumRetries = 120
 	defaultDstWaitTime   = 30 * time.Second
 )
 
@@ -290,7 +290,7 @@ func TestE2E_ApexTestnetBridge_InvalidScenarios(t *testing.T) {
 	require.NoError(t, err)
 
 	const (
-		requestStateTimeoutSec = 600
+		requestStateTimeoutSec = 1500
 	)
 
 	t.Run("Prime to Vector mismatch submitted and receiver amounts", func(t *testing.T) {


### PR DESCRIPTION
# Description

Increased timeouts for e2e testnet tests

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
