### PR TITLE
debug_memTrace

### DIFF
--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -339,6 +339,26 @@ func (d *Debug) GoTrace(file string, nsec int64) (interface{}, error) {
 	)
 }
 
+// MemTrace prints current heap allocation within blade into the file.
+// The file can be later analysed with go tool pprof.
+func (d *Debug) MemTrace(file string) (interface{}, error) {
+	return d.throttling.AttemptRequest(
+		context.Background(),
+		func() (interface{}, error) {
+			if err := d.handler.MemTrace(file); err != nil {
+				return nil, err
+			}
+
+			absPath, err := filepath.Abs(file)
+			if err != nil {
+				return nil, err
+			}
+
+			return absPath, nil
+		},
+	)
+}
+
 // PrintBlock retrieves a block and returns its pretty printed form.
 func (d *Debug) PrintBlock(number uint64) (interface{}, error) {
 	return d.throttling.AttemptRequest(

--- a/jsonrpc/debug_handler.go
+++ b/jsonrpc/debug_handler.go
@@ -127,6 +127,21 @@ func (debug *DebugHandler) StopGoTrace() error {
 	return nil
 }
 
+// MemTrace prints current heap allocation within blade into the file.
+// The file can be later analysed with go tool pprof.
+func (*DebugHandler) MemTrace(file string) error {
+	f, err := os.Create(expandHomeDirectory(file))
+	if err != nil {
+		return err
+	}
+
+	if err := pprof.Lookup("heap").WriteTo(f, 0); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Stacks returns a printed representation of the stacks of all goroutines. It
 // also permits the following optional filters to be used:
 //   - filter: boolean expression of packages to filter for

--- a/jsonrpc/debug_handler.go
+++ b/jsonrpc/debug_handler.go
@@ -135,11 +135,7 @@ func (*DebugHandler) MemTrace(file string) error {
 		return err
 	}
 
-	if err := pprof.Lookup("heap").WriteTo(f, 0); err != nil {
-		return err
-	}
-
-	return nil
+	return pprof.Lookup("heap").WriteTo(f, 0)
 }
 
 // Stacks returns a printed representation of the stacks of all goroutines. It


### PR DESCRIPTION
# Description

debug_memTrace prints current blade heap allocation into a file. The file can be later analysed with go tool pprof. Useful for memory leakage profiling.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually