### PR TITLE
AD-791: Local tests panic during cluster shutdown sequence

### DIFF
--- a/.github/workflows/apex-ci.yml
+++ b/.github/workflows/apex-ci.yml
@@ -207,7 +207,7 @@ jobs:
       apex_bridge_ref: ${{ needs.inputs_check.outputs.apex_bridge_ref }}
       blade_apex_bridge_ref: ${{ needs.inputs_check.outputs.blade_apex_bridge_ref }}
       e2e_apex_big_test: ${{ inputs.e2e_apex_big_test || 'false' }}
-      e2e_apex_skip_redundant_tests: ${{ needs.inputs_check.outputs.skip_redundant_tests }}
+      e2e_apex_skip_redundant_tests: false
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
   e2e_apex_test_push_develop:

--- a/.github/workflows/apex-ci.yml
+++ b/.github/workflows/apex-ci.yml
@@ -207,7 +207,7 @@ jobs:
       apex_bridge_ref: ${{ needs.inputs_check.outputs.apex_bridge_ref }}
       blade_apex_bridge_ref: ${{ needs.inputs_check.outputs.blade_apex_bridge_ref }}
       e2e_apex_big_test: ${{ inputs.e2e_apex_big_test || 'false' }}
-      e2e_apex_skip_redundant_tests: false
+      e2e_apex_skip_redundant_tests: ${{ needs.inputs_check.outputs.skip_redundant_tests }}
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
   e2e_apex_test_push_develop:

--- a/e2e-polybft/framework/node.go
+++ b/e2e-polybft/framework/node.go
@@ -105,8 +105,10 @@ func (n *Node) Stop() error {
 		select {
 		case <-n.Wait():
 		case <-time.After(time.Second * shutdownGracePeriodOnForceStopInSec):
-			for i := 0; i < numberOfInterruptsOnForceStop; i++ {
-				_ = n.cmd.Process.Signal(os.Interrupt)
+			for range numberOfInterruptsOnForceStop {
+				if n.cmd != nil && n.cmd.Process != nil {
+					_ = n.cmd.Process.Signal(os.Interrupt)
+				}
 			}
 
 			<-n.Wait()


### PR DESCRIPTION
# Description

Fixes a race condition in test cluster shutdown where nodes could terminate during the 10-second period (shutdownGracePeriodOnForceStopInSec), causing nil pointer panics when subsequent signals were attempted. Logs show the panic occurring exactly 10 seconds after successful node terminations:

```
2025-08-08T02:17:26.8079268Z cardano node has been terminated: cluster=1, node port=5101
2025-08-08T02:17:26.8105414Z cardano node has been terminated: cluster=5, node port=5503
2025-08-08T02:17:36.7876873Z panic: runtime error: invalid memory address or nil pointer dereference
2025-08-08T02:17:36.7878202Z [signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0x1f103ee
```
The fix introduces a check whether process is already down before another attempt.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
